### PR TITLE
Update API endpoints for MaxMind products and services

### DIFF
--- a/yii-dressing/components/YdMinFraud.php
+++ b/yii-dressing/components/YdMinFraud.php
@@ -3,7 +3,7 @@
 /**
  * YdMinFraud
  *
- * @link http://www.maxmind.com/app/ccv
+ * @link https://minfraud.maxmind.com/app/ccv
  *
  * Usage:
  * Yii::app()->minFraud->getMinFraud(array(
@@ -42,7 +42,7 @@ class YdMinFraud extends CApplicationComponent
         $options['license_key'] = $this->licenseKey;
         $minfraud = array();
         YdCurl::$followLocation = 0;
-        $minfraud_contents = YdCurl::download('https://minfraud1.maxmind.com/app/ccv2r?' . http_build_query($options));
+        $minfraud_contents = YdCurl::download('https://minfraud.maxmind.com/app/ccv2r?' . http_build_query($options));
         YdCurl::$followLocation = 1;
         if ($minfraud_contents) {
             $minfraud_array = explode(';', $minfraud_contents);


### PR DESCRIPTION
MaxMind is beginning to enforce policies around its API endpoints. Endpoints should use the correct hostname for the product or service, and should always use HTTPS.

[Release Note.](https://dev.maxmind.com/geoip/release-notes/2023#api-policies---temporary-enforcement-on-october-17-2023)